### PR TITLE
Pass the verbose flag to get more details about the test runs.

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -22,7 +22,7 @@ jobs:
         CI: true
         NODE_ENV: "prod"  # "test" was casusing SSR to fail.
       run: |
-        yarn run test:e2e
+        yarn run test:e2e --verbose
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Since these are run in CI a summary isn't as nice (since the logs are
output into a file that can be viewed optionally rather than in a
terminal).