### PR TITLE
Show which is the currently selected item in the navigation.

### DIFF
--- a/graphql-types.ts
+++ b/graphql-types.ts
@@ -2499,6 +2499,17 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___plugins___ssrAPIs'
   | 'pluginCreator___pluginOptions___plugins___pluginFilepath'
   | 'pluginCreator___pluginOptions___maxWidth'
+  | 'pluginCreator___pluginOptions___pathPrefix'
+  | 'pluginCreator___pluginOptions___wrapperStyle'
+  | 'pluginCreator___pluginOptions___backgroundColor'
+  | 'pluginCreator___pluginOptions___linkImagesToOriginal'
+  | 'pluginCreator___pluginOptions___showCaptions'
+  | 'pluginCreator___pluginOptions___markdownCaptions'
+  | 'pluginCreator___pluginOptions___withWebp'
+  | 'pluginCreator___pluginOptions___tracedSVG'
+  | 'pluginCreator___pluginOptions___loading'
+  | 'pluginCreator___pluginOptions___disableBgImageOnAlpha'
+  | 'pluginCreator___pluginOptions___disableBgImage'
   | 'pluginCreator___pluginOptions___name'
   | 'pluginCreator___pluginOptions___path'
   | 'pluginCreator___pluginOptions___feeds'
@@ -2702,10 +2713,32 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___plugins___name'
   | 'pluginOptions___plugins___version'
   | 'pluginOptions___plugins___pluginOptions___maxWidth'
+  | 'pluginOptions___plugins___pluginOptions___pathPrefix'
+  | 'pluginOptions___plugins___pluginOptions___wrapperStyle'
+  | 'pluginOptions___plugins___pluginOptions___backgroundColor'
+  | 'pluginOptions___plugins___pluginOptions___linkImagesToOriginal'
+  | 'pluginOptions___plugins___pluginOptions___showCaptions'
+  | 'pluginOptions___plugins___pluginOptions___markdownCaptions'
+  | 'pluginOptions___plugins___pluginOptions___withWebp'
+  | 'pluginOptions___plugins___pluginOptions___tracedSVG'
+  | 'pluginOptions___plugins___pluginOptions___loading'
+  | 'pluginOptions___plugins___pluginOptions___disableBgImageOnAlpha'
+  | 'pluginOptions___plugins___pluginOptions___disableBgImage'
   | 'pluginOptions___plugins___browserAPIs'
   | 'pluginOptions___plugins___ssrAPIs'
   | 'pluginOptions___plugins___pluginFilepath'
   | 'pluginOptions___maxWidth'
+  | 'pluginOptions___pathPrefix'
+  | 'pluginOptions___wrapperStyle'
+  | 'pluginOptions___backgroundColor'
+  | 'pluginOptions___linkImagesToOriginal'
+  | 'pluginOptions___showCaptions'
+  | 'pluginOptions___markdownCaptions'
+  | 'pluginOptions___withWebp'
+  | 'pluginOptions___tracedSVG'
+  | 'pluginOptions___loading'
+  | 'pluginOptions___disableBgImageOnAlpha'
+  | 'pluginOptions___disableBgImage'
   | 'pluginOptions___name'
   | 'pluginOptions___path'
   | 'pluginOptions___feeds'
@@ -2833,6 +2866,17 @@ export type SitePluginPackageJsonPeerDependenciesFilterListInput = {
 export type SitePluginPluginOptions = {
   plugins?: Maybe<Array<Maybe<SitePluginPluginOptionsPlugins>>>;
   maxWidth?: Maybe<Scalars['Int']>;
+  pathPrefix?: Maybe<Scalars['String']>;
+  wrapperStyle?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']>;
+  linkImagesToOriginal?: Maybe<Scalars['Boolean']>;
+  showCaptions?: Maybe<Scalars['Boolean']>;
+  markdownCaptions?: Maybe<Scalars['Boolean']>;
+  withWebp?: Maybe<Scalars['Boolean']>;
+  tracedSVG?: Maybe<Scalars['Boolean']>;
+  loading?: Maybe<Scalars['String']>;
+  disableBgImageOnAlpha?: Maybe<Scalars['Boolean']>;
+  disableBgImage?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
   feeds?: Maybe<Array<Maybe<SitePluginPluginOptionsFeeds>>>;
@@ -2861,6 +2905,17 @@ export type SitePluginPluginOptionsFeedsFilterListInput = {
 export type SitePluginPluginOptionsFilterInput = {
   plugins?: Maybe<SitePluginPluginOptionsPluginsFilterListInput>;
   maxWidth?: Maybe<IntQueryOperatorInput>;
+  pathPrefix?: Maybe<StringQueryOperatorInput>;
+  wrapperStyle?: Maybe<StringQueryOperatorInput>;
+  backgroundColor?: Maybe<StringQueryOperatorInput>;
+  linkImagesToOriginal?: Maybe<BooleanQueryOperatorInput>;
+  showCaptions?: Maybe<BooleanQueryOperatorInput>;
+  markdownCaptions?: Maybe<BooleanQueryOperatorInput>;
+  withWebp?: Maybe<BooleanQueryOperatorInput>;
+  tracedSVG?: Maybe<BooleanQueryOperatorInput>;
+  loading?: Maybe<StringQueryOperatorInput>;
+  disableBgImageOnAlpha?: Maybe<BooleanQueryOperatorInput>;
+  disableBgImage?: Maybe<BooleanQueryOperatorInput>;
   name?: Maybe<StringQueryOperatorInput>;
   path?: Maybe<StringQueryOperatorInput>;
   feeds?: Maybe<SitePluginPluginOptionsFeedsFilterListInput>;
@@ -2898,10 +2953,32 @@ export type SitePluginPluginOptionsPluginsFilterListInput = {
 
 export type SitePluginPluginOptionsPluginsPluginOptions = {
   maxWidth?: Maybe<Scalars['Int']>;
+  pathPrefix?: Maybe<Scalars['String']>;
+  wrapperStyle?: Maybe<Scalars['String']>;
+  backgroundColor?: Maybe<Scalars['String']>;
+  linkImagesToOriginal?: Maybe<Scalars['Boolean']>;
+  showCaptions?: Maybe<Scalars['Boolean']>;
+  markdownCaptions?: Maybe<Scalars['Boolean']>;
+  withWebp?: Maybe<Scalars['Boolean']>;
+  tracedSVG?: Maybe<Scalars['Boolean']>;
+  loading?: Maybe<Scalars['String']>;
+  disableBgImageOnAlpha?: Maybe<Scalars['Boolean']>;
+  disableBgImage?: Maybe<Scalars['Boolean']>;
 };
 
 export type SitePluginPluginOptionsPluginsPluginOptionsFilterInput = {
   maxWidth?: Maybe<IntQueryOperatorInput>;
+  pathPrefix?: Maybe<StringQueryOperatorInput>;
+  wrapperStyle?: Maybe<StringQueryOperatorInput>;
+  backgroundColor?: Maybe<StringQueryOperatorInput>;
+  linkImagesToOriginal?: Maybe<BooleanQueryOperatorInput>;
+  showCaptions?: Maybe<BooleanQueryOperatorInput>;
+  markdownCaptions?: Maybe<BooleanQueryOperatorInput>;
+  withWebp?: Maybe<BooleanQueryOperatorInput>;
+  tracedSVG?: Maybe<BooleanQueryOperatorInput>;
+  loading?: Maybe<StringQueryOperatorInput>;
+  disableBgImageOnAlpha?: Maybe<BooleanQueryOperatorInput>;
+  disableBgImage?: Maybe<BooleanQueryOperatorInput>;
 };
 
 export type SitePluginSortInput = {

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -4,7 +4,7 @@ import Link from "gatsby-link";
 
 import Icon from "../components/icon";
 
-const Navigation = (): JSX.Element => {
+const Navigation = (props: { pathname?: string }): JSX.Element => {
   return (
     <nav className="navigation">
       <section className="container">
@@ -18,10 +18,16 @@ const Navigation = (): JSX.Element => {
         </label>
 
         <ul className="navigation-list">
-          <li className="navigation-item">
+          <li
+            aria-current={props.pathname === "/" ? "page" : undefined}
+            className="navigation-item"
+          >
             <Link to="/">Home</Link>
           </li>
-          <li className="navigation-item">
+          <li
+            aria-current={props.pathname === "/blog/" ? "page" : undefined}
+            className="navigation-item"
+          >
             <Link to="/blog/">Blog</Link>
           </li>
         </ul>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import classNames from "classnames";
 import Link from "gatsby-link";
 
 import Icon from "../components/icon";
@@ -8,7 +9,12 @@ const Navigation = (props: { pathname?: string }): JSX.Element => {
   return (
     <nav className="navigation">
       <section className="container">
-        <Link to="/" className="navigation-title">
+        <Link
+          to="/"
+          className={classNames("navigation-title", {
+            active: props.pathname === "/",
+          })}
+        >
           hockeybuggy.com
         </Link>
 

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -8,6 +8,7 @@ import Navigation from "../components/navigation";
 
 interface LayoutProps extends React.HTMLAttributes<any> {
   className?: string;
+  pathname?: string;
   children: React.ReactNode;
 }
 
@@ -17,28 +18,32 @@ const InnerContainer: React.FC<LayoutProps> = (props) => (
   </section>
 );
 
-export const BaseLayout: React.FC<LayoutProps> = (props) => (
-  <React.Fragment>
-    <Helmet>
-      <link
-        href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&family=Lato:wght@400;700&family=Merriweather:wght@400;700&display=swap"
-        rel="stylesheet"
-      />
-      <link rel="icon" href="/static/img/favicon.ico" />
-    </Helmet>
+export const BaseLayout: React.FC<LayoutProps> = (props) => {
+  return (
+    <React.Fragment>
+      <Helmet>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&family=Lato:wght@400;700&family=Merriweather:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+        <link rel="icon" href="/static/img/favicon.ico" />
+      </Helmet>
 
-    <main className="wrapper">
-      <div className="header">
-        <Navigation />
-      </div>
-      <div className="content">
-        <InnerContainer {...props} />
-      </div>
-      <Footer />
-    </main>
-  </React.Fragment>
-);
+      <main className="wrapper">
+        <div className="header">
+          <Navigation pathname={props.pathname} />
+        </div>
+        <div className="content">
+          <InnerContainer {...props} />
+        </div>
+        <Footer />
+      </main>
+    </React.Fragment>
+  );
+};
 
 export const CenteredLayout: React.FC<LayoutProps> = (props) => (
-  <BaseLayout className="centered">{props.children}</BaseLayout>
+  <BaseLayout className="centered" {...props}>
+    {props.children}
+  </BaseLayout>
 );

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -11,7 +11,7 @@ const BlogIndex = ({ data }: PageProps<BlogIndexPageQuery>): JSX.Element => {
   const posts = data.allBlogPosts.edges;
 
   return (
-    <BaseLayout>
+    <BaseLayout pathname={"/blog/"}>
       <SEO title={"Blog"} />
 
       <h1>Blog Posts</h1>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,7 +33,7 @@ const IndexPage = ({ data }: PageProps<IndexPageQuery>): JSX.Element => {
   const description = data.site!.siteMetadata!.description!;
 
   return (
-    <CenteredLayout>
+    <CenteredLayout pathname={"/"}>
       <SEO title={description} />
       <div className="about">
         <div className="avatar">

--- a/src/styles/_navigation.scss
+++ b/src/styles/_navigation.scss
@@ -22,6 +22,10 @@
   .navigation-title {
     letter-spacing: 0.1rem;
     text-transform: uppercase;
+
+    &.active {
+      text-decoration: underline;
+    }
   }
 
   .navigation-list {

--- a/src/styles/_navigation.scss
+++ b/src/styles/_navigation.scss
@@ -44,10 +44,16 @@
       border-bottom: solid 2px $alt-bg-color;
       transition: opacity 0.25s, max-height 0.15s linear;
     }
+
     .navigation-item {
       float: left;
       margin: 0;
       position: relative;
+
+      &[aria-current="page"] {
+        text-decoration: underline;
+      }
+
       @media only screen and (max-width: 768px) {
         float: none !important;
         text-align: center;
@@ -56,12 +62,14 @@
           line-height: 5rem;
         }
       }
+
       a,
       span {
         margin-left: 1rem;
         margin-right: 1rem;
       }
     }
+
     .menu-separator {
       @media only screen and (max-width: 768px) {
         border-top: 2px solid $fg-color;


### PR DESCRIPTION
I did this by adding a `pathname` prop to the `navigation` and in turn
the `layouts`. This allows the `li` in the `navigation` to use the
`aria-current` attribute. This attribute is documented here:
https://www.w3.org/TR/wai-aria-1.1/#aria-current . The attribute is then
used to add a small underline to indicate that you are already on the
page for the link.