### PR TITLE
Fix the mailto link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ const social = [
   },
   {
     label: "Email",
-    link: "mailto:://hockeybuggy@gmail.com",
+    link: "mailto:hockeybuggy@gmail.com",
     iconName: Icon.Names.Email,
   },
 ];


### PR DESCRIPTION
This previously had a bad `:://` prefix. This commit removes the prefix
and fixes the link.