### PR TITLE
Avoid skip level headings

### DIFF
--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -30,9 +30,9 @@ const BlogIndex = ({ data }: PageProps<BlogIndexPageQuery>): JSX.Element => {
                   {frontmatter.date}
                 </time>
               </small>
-              <h3 style={{ margin: 0, marginBottom: "1.8rem" }}>
+              <h2 style={{ margin: 0, marginBottom: "1.8rem" }}>
                 <Link to={`/blog/post/${year}/${month}/${slug}`}>{title}</Link>
-              </h3>
+              </h2>
             </header>
             <hr />
           </article>

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -43,7 +43,7 @@ const ProjectsIndex = ({
           <article key={slug}>
             <div className="header-row">
               <header>
-                <h3>{title}</h3>
+                <h2>{title}</h2>
               </header>
               {github ? (
                 <div className="github-link">

--- a/src/styles/_projects_page.scss
+++ b/src/styles/_projects_page.scss
@@ -25,7 +25,7 @@
       header {
         margin: 0;
 
-        h3 {
+        h2 {
           margin: 0;
         }
       }


### PR DESCRIPTION
My blog page and projects page had a top level `h1` then went directly
to an `h3`. This skip level nesting can make it harder to navigate sites
for accessibility tools.

This commit changes this to be a `h2` instead. No considerations for the
larger size have been taken (it looks fine).