### PR TITLE
Pin the node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@types/classnames": "^2.3.1",
     "@types/jest": "^26.0.24",
-    "@types/node": "16.3.3",
+    "@types/node": "14.17.3",
     "@types/react": "^17.0.14",
     "@types/react-dom": "17.0.9",
     "@types/react-helmet": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,10 +2950,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@16.3.3":
+"@types/node@*":
   version "16.3.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.3.3.tgz#0c30adff37bbbc7a50eb9b58fae2a504d0d88038"
   integrity sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==
+
+"@types/node@14.17.3":
+  version "14.17.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.3.tgz#6d327abaa4be34a74e421ed6409a0ae2f47f4c3d"
+  integrity sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==
 
 "@types/node@^14.14.10":
   version "14.14.41"


### PR DESCRIPTION
The node types were updated by Dependabot. This commit pins the back to
matching the current node version.
