### PR TITLE
Remove extra slash in the RSS feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 /.pnp
 .pnp.js
 .cache
+tsconfig.tsbuildinfo
 
 .DS_Store
 !.github/
@@ -11,3 +12,4 @@ node_modules
 /out/
 
 public/blog/index.xml
+

--- a/scripts/build_blog_feed.ts
+++ b/scripts/build_blog_feed.ts
@@ -35,7 +35,7 @@ async function generate() {
 
   await Promise.all(
     posts.map(async (post) => {
-      const postUrl = `https://hockeybuggy.com/${BlogPresentor.getUrlForPost(
+      const postUrl = `https://hockeybuggy.com${BlogPresentor.getUrlForPost(
         post
       )}`;
       const html = await markdownToHtml(post.content);


### PR DESCRIPTION
The RSS feed as is works, but has a very small issues with an extra
slash in it. This commit removes that extra slash.