### PR TITLE
Update the rendering of icons to be of fixed size.

### DIFF
--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -75,17 +75,41 @@ function sizeModifierBySize(size: undefined | IconSizes): SizeProp {
   exhasutiveCheck(size);
 }
 
+function pxBySize(size: undefined | IconSizes): string {
+  switch (size) {
+    case undefined:
+    case IconSizes.Default:
+      return "16px";
+    case IconSizes.Large:
+      return "64px";
+  }
+  exhasutiveCheck(size);
+}
+
 const Icon = ({
   name,
   label,
   size,
+  width,
 }: {
   name: IconNames;
   label: string;
   size?: IconSizes;
+  width?: string;
 }): JSX.Element => (
-  <i className="icon" aria-label={label}>
-    <FontAwesomeIcon icon={iconByName(name)} size={sizeModifierBySize(size)} />
+  <i
+    className="icon"
+    aria-label={label}
+    style={{ width: width || pxBySize(size), height: width || pxBySize(size) }}
+  >
+    <FontAwesomeIcon
+      icon={iconByName(name)}
+      size={sizeModifierBySize(size)}
+      style={{
+        width: width || pxBySize(size),
+        height: width || pxBySize(size),
+      }}
+    />
   </i>
 );
 Icon.Names = IconNames;

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -83,7 +83,7 @@ const Navigation = (props: { pathname?: string }): JSX.Element => {
           aria-controls="menu-inner"
           ref={navigationToggleRef}
         >
-          <Icon name={Icon.Names.Bars} label="" />
+          <Icon name={Icon.Names.Bars} label="" width="24px" />
         </button>
 
         <ul

--- a/styles/_index_page.scss
+++ b/styles/_index_page.scss
@@ -59,6 +59,7 @@
 
     list-style: none;
     margin: 3rem 0 1rem 0;
+    width: 256px;
     padding: 0;
 
     li {


### PR DESCRIPTION
When loading things the icon sizes were not fixed. This commit makes the
icons have a fixed width and height via a style tag.