### PR TITLE
Remove the padding from the `body`

### DIFF
--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -12,6 +12,9 @@ html {
 body {
   color: $light-fg-color;
   background-color: $light-bg-color;
+
+  margin: 0;
+
   font-family: $text-font-family;
   font-size: 1.6em;
   font-weight: 300;


### PR DESCRIPTION
There was an annoying little scroll on the page from the mix of the
`min-height: 100vh` and this little extra default margin on the body.

Closes: https://github.com/hockeybuggy/hockeybuggy.com/issues/1319