### PR TITLE
Remove the RSS feed link from non-blog pages

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,7 +3,11 @@ import Link from "next/link";
 
 import Icon from "../components/icon";
 
-const Footer = (): JSX.Element => {
+interface Props {
+  showRSSLink?: boolean;
+}
+
+const Footer = (props: Props): JSX.Element => {
   return (
     <footer className="footer">
       <section className="container">
@@ -20,12 +24,14 @@ const Footer = (): JSX.Element => {
               label="Creative Commons icon"
             />
           </a>
-          <Link href="/blog/index.xml">
-            <a aria-label="blog atom feed">
-              <Icon name={Icon.Names.RSS} label="RSS feed icon" />
-            </a>
-          </Link>
-          <span>©2021</span>
+          {props.showRSSLink && (
+            <Link href="/blog/index.xml">
+              <a aria-label="blog atom feed">
+                <Icon name={Icon.Names.RSS} label="RSS feed icon" />
+              </a>
+            </Link>
+          )}
+          <span>©2022</span>
         </div>
       </section>
     </footer>

--- a/layouts/index.tsx
+++ b/layouts/index.tsx
@@ -9,6 +9,7 @@ interface LayoutProps extends React.HTMLAttributes<any> {
   className?: string;
   pathname?: string;
   children: React.ReactNode;
+  showRSSLink?: boolean;
 }
 
 const InnerContainer: React.FC<LayoutProps> = (props) => (
@@ -27,7 +28,7 @@ export const BaseLayout: React.FC<LayoutProps> = (props) => {
         <div className="content">
           <InnerContainer {...props} />
         </div>
-        <Footer />
+        <Footer showRSSLink={props.showRSSLink} />
       </main>
     </React.Fragment>
   );
@@ -38,3 +39,7 @@ export const CenteredLayout: React.FC<LayoutProps> = (props) => (
     {props.children}
   </BaseLayout>
 );
+
+export const BlogLayout: React.FC<LayoutProps> = (props) => {
+  return <BaseLayout showRSSLink {...props} />;
+};

--- a/pages/blog/categories/[category].tsx
+++ b/pages/blog/categories/[category].tsx
@@ -3,7 +3,7 @@ import { GetStaticPropsResult, GetStaticPathsResult } from "next";
 import Link from "next/link";
 import uniq from "lodash/uniq";
 
-import { BaseLayout } from "../../../layouts";
+import { BlogLayout } from "../../../layouts";
 import SEO from "../../../components/seo";
 
 import { Post } from "../../../models/blog";
@@ -20,7 +20,7 @@ const CategoryPage = ({ posts, category }: Props): JSX.Element => {
     totalCount === 1 ? "" : "s"
   } in the category "${category}"`;
   return (
-    <BaseLayout>
+    <BlogLayout>
       <SEO title={`Category: ${category}`} />
       <h1>{categoryHeader}</h1>
       <ul>
@@ -37,7 +37,7 @@ const CategoryPage = ({ posts, category }: Props): JSX.Element => {
         })}
       </ul>
       <Link href="/blog/categories">All categories</Link>
-    </BaseLayout>
+    </BlogLayout>
   );
 };
 type Params = {

--- a/pages/blog/categories/index.tsx
+++ b/pages/blog/categories/index.tsx
@@ -3,7 +3,7 @@ import { GetStaticPropsResult } from "next";
 import Link from "next/link";
 import kebabCase from "lodash/kebabCase";
 
-import { BaseLayout } from "../../../layouts";
+import { BlogLayout } from "../../../layouts";
 import SEO from "../../../components/seo";
 
 import { getAllPosts } from "../../../services/blog";
@@ -34,7 +34,7 @@ const CategoriesIndexPage = ({
   postsGroupedByCategory,
 }: Props): JSX.Element => {
   return (
-    <BaseLayout>
+    <BlogLayout>
       <SEO title={"Categories"} />
       <div>
         <h1>Categories</h1>
@@ -44,7 +44,7 @@ const CategoriesIndexPage = ({
           ))}
         </ul>
       </div>
-    </BaseLayout>
+    </BlogLayout>
   );
 };
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { GetStaticPropsResult } from "next";
 import Link from "next/link";
 
-import { BaseLayout } from "../../layouts";
+import { BlogLayout } from "../../layouts";
 import SEO from "../../components/seo";
 
 import { Post } from "../../models/blog";
@@ -15,7 +15,7 @@ interface Props {
 
 const BlogIndex = ({ allPosts }: Props): JSX.Element => {
   return (
-    <BaseLayout pathname={"/blog/"}>
+    <BlogLayout pathname={"/blog/"}>
       <SEO title={"Blog"} />
 
       <h1>Blog Posts</h1>
@@ -40,7 +40,7 @@ const BlogIndex = ({ allPosts }: Props): JSX.Element => {
           </article>
         );
       })}
-    </BaseLayout>
+    </BlogLayout>
   );
 };
 

--- a/pages/blog/post/[year]/[month]/[slug].tsx
+++ b/pages/blog/post/[year]/[month]/[slug].tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { GetStaticPropsResult, GetStaticPathsResult } from "next";
 import Link from "next/link";
 
-import { BaseLayout } from "../../../../../layouts";
+import { BlogLayout } from "../../../../../layouts";
 import SEO from "../../../../../components/seo";
 import Icon from "../../../../../components/icon";
 
@@ -26,7 +26,7 @@ const BlogPostPage = ({ post, html, excerpt }: Props): JSX.Element => {
   const humanDate = BlogPresentor.getHumanReadableDateOfPost(post);
 
   return (
-    <BaseLayout className="post">
+    <BlogLayout className="post">
       <SEO title={title!} description={excerpt} />
       <article>
         <header>
@@ -68,7 +68,7 @@ const BlogPostPage = ({ post, html, excerpt }: Props): JSX.Element => {
         <section dangerouslySetInnerHTML={{ __html: html }} />
         <hr />
       </article>
-    </BaseLayout>
+    </BlogLayout>
   );
 };
 

--- a/pages/blog/tags/[tag].tsx
+++ b/pages/blog/tags/[tag].tsx
@@ -3,7 +3,7 @@ import { GetStaticPropsResult, GetStaticPathsResult } from "next";
 import Link from "next/link";
 import uniq from "lodash/uniq";
 
-import { BaseLayout } from "../../../layouts";
+import { BlogLayout } from "../../../layouts";
 import SEO from "../../../components/seo";
 
 import { Post } from "../../../models/blog";
@@ -20,7 +20,7 @@ const TagPage = ({ posts, tag }: Props): JSX.Element => {
     totalCount === 1 ? "" : "s"
   } in with the tag "${tag}"`;
   return (
-    <BaseLayout>
+    <BlogLayout>
       <SEO title={`Tag: ${tag}`} />
       <h1>{tagHeader}</h1>
       <ul>
@@ -37,7 +37,7 @@ const TagPage = ({ posts, tag }: Props): JSX.Element => {
         })}
       </ul>
       <Link href="/blog/tags">All tags</Link>
-    </BaseLayout>
+    </BlogLayout>
   );
 };
 type Params = {

--- a/pages/blog/tags/index.tsx
+++ b/pages/blog/tags/index.tsx
@@ -3,7 +3,7 @@ import { GetStaticPropsResult } from "next";
 import Link from "next/link";
 import kebabCase from "lodash/kebabCase";
 
-import { BaseLayout } from "../../../layouts";
+import { BlogLayout } from "../../../layouts";
 import SEO from "../../../components/seo";
 
 import { getAllPosts } from "../../../services/blog";
@@ -26,7 +26,7 @@ const Tag = ({ tags, count }: { tags: string; count: number }): JSX.Element => {
 
 const TagsIndexPage = ({ postsGroupedByTag }: Props): JSX.Element => {
   return (
-    <BaseLayout>
+    <BlogLayout>
       <SEO title={"Tags"} />
       <div>
         <h1>Tags</h1>
@@ -36,7 +36,7 @@ const TagsIndexPage = ({ postsGroupedByTag }: Props): JSX.Element => {
           ))}
         </ul>
       </div>
-    </BaseLayout>
+    </BlogLayout>
   );
 };
 


### PR DESCRIPTION
Previously the footer contained a link to the RSS feed for every page.
This was a little weird on the projects page where it would be
conceivable to have a feed that included updates to items there.

This achieves this by creating a `BlogLayout` which passes a long a new
prop to the footer.

Closes: https://github.com/hockeybuggy/hockeybuggy.com/issues/1318