### PR TITLE
Change to weekly dependency updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "10:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
There isn't really a good reason to build this often and it's costing
more build minutes than I would like to use.