### PR TITLE
Add a sitemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ tsconfig.tsbuildinfo
 /.next/
 /out/
 
+# We generate the following files via the prebuild script
+public/sitemap.xml
 public/blog/index.xml
-

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "prebuild": "ts-node ./scripts/build_blog_feed.ts",
+    "prebuild": "ts-node ./scripts/build_blog_feed.ts && ts-node ./scripts/build_sitemap.ts",
     "start": "next start",
     "dev": "next",
     "lint": "eslint \"**/*.ts*\"",

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -80,7 +80,9 @@ const ProjectsIndex = ({
               dangerouslySetInnerHTML={{ __html: excerpt }}
             />
             <div className="read-more">
-              <Link href={`/project/${project.slug}`}>Read more</Link>
+              <Link href={ProjectPresentor.getUrlForProject(project)}>
+                Read more
+              </Link>
             </div>
           </article>
         );

--- a/scripts/build_blog_feed.ts
+++ b/scripts/build_blog_feed.ts
@@ -14,11 +14,11 @@ async function generate() {
   const feed = new Feed({
     title: "Hockeybuggy.com",
     description: "The personal website of Douglas Anderson",
-    id: "http://hockeybuggy.com/blog",
-    link: "http://hockeybuggy.com/blog",
+    id: "https://hockeybuggy.com/blog",
+    link: "https://hockeybuggy.com/blog",
     language: "en",
-    image: "http://hockeybuggy.com/image.png",
-    favicon: "http://hockeybuggy.com/favicon.ico",
+    image: "https://hockeybuggy.com/image.png",
+    favicon: "https://hockeybuggy.com/favicon.ico",
     copyright: "Creative commons 2021, Douglas Anderson",
     generator: "Feed with Next.js",
     feedLinks: {

--- a/scripts/build_sitemap.ts
+++ b/scripts/build_sitemap.ts
@@ -1,0 +1,74 @@
+import { writeFileSync, mkdirSync } from "fs";
+
+import { getAllPosts } from "../services/blog";
+import { getAllProjects } from "../services/projects";
+import { BlogPresentor } from "../services/presentors/blog";
+import { ProjectPresentor } from "../services/presentors/project";
+
+// Based roughly on this: https://www.sitemaps.org/protocol.html
+interface SiteMapPageInfo {
+  loc: string;
+  lastmod?: string;
+}
+
+function generateSiteMap(pages: Array<SiteMapPageInfo>) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+     ${pages
+       .map(({ loc, lastmod }) => {
+         return `
+       <url>
+           <loc>${`${loc}`}</loc>
+           ${lastmod ? `<lastmod>${`${lastmod}`}</lastmod>` : ""}
+       </url>
+     `;
+       })
+       .join("")}
+   </urlset>
+ `;
+}
+
+const BASE = "https://hockeybuggy.com";
+
+async function generate() {
+  console.log("Generating Sitemap...");
+
+  const pages: Array<SiteMapPageInfo> = [
+    {
+      loc: `${BASE}`,
+    },
+  ];
+
+  console.log("Adding pages for the blog...");
+  pages.push({
+    loc: `${BASE}/blog/`,
+  });
+  const allPosts = getAllPosts();
+  const allListedPosts = allPosts.filter((post) => !post.delisted);
+  allListedPosts.forEach((post) => {
+    const postUrl = `${BASE}${BlogPresentor.getUrlForPost(post)}`;
+    const postLastMod = post.isoDate;
+    pages.push({
+      loc: postUrl,
+      lastmod: postLastMod,
+    });
+  });
+
+  console.log("Adding pages for the projects...");
+  pages.push({
+    loc: `${BASE}/projects/`,
+  });
+  const allProjects = getAllProjects();
+  allProjects.forEach((project) => {
+    const projectUrl = `${BASE}${ProjectPresentor.getUrlForProject(project)}`;
+    pages.push({ loc: projectUrl });
+  });
+
+  const sitemap = generateSiteMap(pages);
+  mkdirSync("public", { recursive: true });
+  writeFileSync("public/sitemap.xml", sitemap);
+
+  console.log("Done.");
+}
+
+generate();


### PR DESCRIPTION
I just learned that the site hasn't had a sitemap since the hugo days and there is a pretty big dropoff that may be associated with that. I think that would account for the project pages having effectively never gotten organic hits.


It's set here: https://github.com/hockeybuggy/hockeybuggy.com/blob/fcd147f23a8f4ee391c4baea03e75882881696bb/public/robots.txt#L6


<img width="1256" alt="Screenshot 2023-02-18 at 20 47 48" src="https://user-images.githubusercontent.com/607279/219906019-36bd5f5b-62d4-4739-8dea-44ca9de3aa3a.png">


Closes: https://github.com/hockeybuggy/hockeybuggy.com/issues/1843