### PR TITLE
Fix trailing slash redirects in sitemap

### DIFF
--- a/scripts/build_sitemap.ts
+++ b/scripts/build_sitemap.ts
@@ -41,7 +41,7 @@ async function generate() {
 
   console.log("Adding pages for the blog...");
   pages.push({
-    loc: `${BASE}/blog/`,
+    loc: `${BASE}/blog`,
   });
   const allPosts = getAllPosts();
   const allListedPosts = allPosts.filter((post) => !post.delisted);
@@ -56,7 +56,7 @@ async function generate() {
 
   console.log("Adding pages for the projects...");
   pages.push({
-    loc: `${BASE}/projects/`,
+    loc: `${BASE}/projects`,
   });
   const allProjects = getAllProjects();
   allProjects.forEach((project) => {


### PR DESCRIPTION
Google tells me that these pages are getting redirected. This is because we don't allow trailing slashes currently.

It would be ideal to have a way to check the site map vs the generated pages. Created
https://github.com/hockeybuggy/hockeybuggy.com/issues/1855 to track that.