### PR TITLE
Include tags and categories in the sitemap.

### DIFF
--- a/pages/blog/categories/[category].tsx
+++ b/pages/blog/categories/[category].tsx
@@ -8,6 +8,7 @@ import SEO from "../../../components/seo";
 
 import { Post } from "../../../models/blog";
 import { getAllPosts } from "../../../services/blog";
+import { BlogPresentor } from "../../../services/presentors/blog";
 
 interface Props {
   posts: Post[];
@@ -26,12 +27,10 @@ const CategoryPage = ({ posts, category }: Props): JSX.Element => {
       <ul>
         {posts.map((post) => {
           const slug = post.slug;
-          const year = post.year;
-          const month = post.month;
           const title = post.title;
           return (
             <li key={slug}>
-              <Link href={`/blog/post/${year}/${month}/${slug}`}>{title}</Link>
+              <Link href={BlogPresentor.getUrlForPost(post)}>{title}</Link>
             </li>
           );
         })}

--- a/pages/blog/categories/index.tsx
+++ b/pages/blog/categories/index.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import { GetStaticPropsResult } from "next";
 import Link from "next/link";
-import kebabCase from "lodash/kebabCase";
 
 import { BlogLayout } from "../../../layouts";
 import SEO from "../../../components/seo";
 
-import { getAllPosts } from "../../../services/blog";
+import {
+  getAllPosts,
+  getCategoryCountsFromPosts,
+} from "../../../services/blog";
+import { BlogPresentor } from "../../../services/presentors/blog";
 
-interface Props {
-  postsGroupedByCategory: Record<string, number>;
+interface CategoriesIndexPageProps {
+  categoryCounts: Record<string, number>;
 }
 
 const Category = ({
@@ -21,7 +24,7 @@ const Category = ({
 }): JSX.Element => {
   return (
     <li key={category}>
-      <Link href={`/blog/categories/${kebabCase(category)}/`}>
+      <Link href={BlogPresentor.getUrlForCategoryPage(category)}>
         {category} ({count})
       </Link>
     </li>
@@ -29,16 +32,16 @@ const Category = ({
 };
 
 const CategoriesIndexPage = ({
-  postsGroupedByCategory,
-}: Props): JSX.Element => {
+  categoryCounts,
+}: CategoriesIndexPageProps): JSX.Element => {
   return (
     <BlogLayout>
       <SEO title={"Categories"} />
       <div>
         <h1>Categories</h1>
         <ul>
-          {Object.entries(postsGroupedByCategory).map(([category, value]) => (
-            <Category key={category} category={category} count={value} />
+          {Object.entries(categoryCounts).map(([category, count]) => (
+            <Category key={category} category={category} count={count} />
           ))}
         </ul>
       </div>
@@ -46,22 +49,14 @@ const CategoriesIndexPage = ({
   );
 };
 
-export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
+export async function getStaticProps(): Promise<
+  GetStaticPropsResult<CategoriesIndexPageProps>
+> {
   const allPosts = getAllPosts();
-  // Filter to posts that have the category
-  const postsGroupedByCategory: Record<string, number> = {};
-  allPosts.forEach((post) => {
-    post.categories.forEach((category) => {
-      if (postsGroupedByCategory[category] === undefined) {
-        postsGroupedByCategory[category] = 1;
-      } else {
-        postsGroupedByCategory[category] += 1;
-      }
-    });
-  });
+  const categoryCounts = getCategoryCountsFromPosts(allPosts);
 
   return {
-    props: { postsGroupedByCategory },
+    props: { categoryCounts },
   };
 }
 

--- a/pages/blog/tags/index.tsx
+++ b/pages/blog/tags/index.tsx
@@ -15,7 +15,7 @@ interface TagsIndexPageProps {
 const Tag = ({ tag, count }: { tag: string; count: number }): JSX.Element => {
   return (
     <li key={tag}>
-      <Link href={BlogPresentor.getUrlForCategoryPage(tag)}>
+      <Link href={BlogPresentor.getUrlForTagPage(tag)}>
         {tag} ({count})
       </Link>
     </li>

--- a/pages/blog/tags/index.tsx
+++ b/pages/blog/tags/index.tsx
@@ -1,40 +1,40 @@
 import React from "react";
 import { GetStaticPropsResult } from "next";
 import Link from "next/link";
-import kebabCase from "lodash/kebabCase";
 
 import { BlogLayout } from "../../../layouts";
 import SEO from "../../../components/seo";
 
-import { getAllPosts } from "../../../services/blog";
+import { getAllPosts, getTagCountsFromPosts } from "../../../services/blog";
+import { BlogPresentor } from "../../../services/presentors/blog";
 
-interface Props {
-  postsGroupedByTag: Record<string, number>;
+interface TagsIndexPageProps {
+  tagCounts: Record<string, number>;
 }
 
-const Tag = ({ tags, count }: { tags: string; count: number }): JSX.Element => {
+const Tag = ({ tag, count }: { tag: string; count: number }): JSX.Element => {
   return (
-    <li key={tags}>
-      <Link href={`/blog/tags/${kebabCase(tags)}/`}>
-        {tags} ({count})
+    <li key={tag}>
+      <Link href={BlogPresentor.getUrlForCategoryPage(tag)}>
+        {tag} ({count})
       </Link>
     </li>
   );
 };
 
-const TagsIndexPage = ({ postsGroupedByTag }: Props): JSX.Element => {
+const TagsIndexPage = ({ tagCounts }: TagsIndexPageProps): JSX.Element => {
   return (
     <BlogLayout>
       <SEO title={"Tags"} />
       <div>
         <h1>Tags</h1>
         <ul>
-          {Object.entries(postsGroupedByTag)
+          {Object.entries(tagCounts)
             .sort((a, b) => {
               return a[0].localeCompare(b[0]);
             })
-            .map(([tags, value]) => (
-              <Tag key={tags} tags={tags} count={value} />
+            .map(([tag, value]) => (
+              <Tag key={tag} tag={tag} count={value} />
             ))}
         </ul>
       </div>
@@ -42,22 +42,15 @@ const TagsIndexPage = ({ postsGroupedByTag }: Props): JSX.Element => {
   );
 };
 
-export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
+export async function getStaticProps(): Promise<
+  GetStaticPropsResult<TagsIndexPageProps>
+> {
   const allPosts = getAllPosts();
   // Filter to posts that have the tags
-  const postsGroupedByTag: Record<string, number> = {};
-  allPosts.forEach((post) => {
-    post.tags.forEach((tags) => {
-      if (postsGroupedByTag[tags] === undefined) {
-        postsGroupedByTag[tags] = 1;
-      } else {
-        postsGroupedByTag[tags] += 1;
-      }
-    });
-  });
+  const tagCounts = getTagCountsFromPosts(allPosts);
 
   return {
-    props: { postsGroupedByTag },
+    props: { tagCounts },
   };
 }
 

--- a/scripts/build_sitemap.ts
+++ b/scripts/build_sitemap.ts
@@ -56,8 +56,7 @@ async function generate() {
     loc: `${BASE}/blog`,
   });
   const allPosts = getAllPosts();
-  const allListedPosts = allPosts.filter((post) => !post.delisted);
-  allListedPosts.forEach((post) => {
+  allPosts.forEach((post) => {
     const postUrl = `${BASE}${BlogPresentor.getUrlForPost(post)}`;
     const postLastMod = post.isoDate;
     pages.push({

--- a/services/blog.ts
+++ b/services/blog.ts
@@ -47,3 +47,35 @@ export function getAllPosts(): Post[] {
 export function getPostBySlug(slug: string): Post | null {
   return getAllPosts().filter((post) => post.slug === slug)[0];
 }
+
+export function getCategoryCountsFromPosts(
+  posts: Array<Post>
+): Record<string, number> {
+  const postsGroupedByCategory: Record<string, number> = {};
+  posts.forEach((post) => {
+    post.categories.forEach((category) => {
+      if (postsGroupedByCategory[category] === undefined) {
+        postsGroupedByCategory[category] = 1;
+      } else {
+        postsGroupedByCategory[category] += 1;
+      }
+    });
+  });
+  return postsGroupedByCategory;
+}
+
+export function getTagCountsFromPosts(
+  posts: Array<Post>
+): Record<string, number> {
+  const postsGroupedByTag: Record<string, number> = {};
+  posts.forEach((post) => {
+    post.tags.forEach((tags) => {
+      if (postsGroupedByTag[tags] === undefined) {
+        postsGroupedByTag[tags] = 1;
+      } else {
+        postsGroupedByTag[tags] += 1;
+      }
+    });
+  });
+  return postsGroupedByTag;
+}

--- a/services/presentors/blog.ts
+++ b/services/presentors/blog.ts
@@ -1,4 +1,5 @@
 import { parseISO, format } from "date-fns";
+import kebabCase from "lodash/kebabCase";
 
 import { Post } from "../../models/blog";
 
@@ -6,6 +7,14 @@ export class BlogPresentor {
   static getUrlForPost(post: Post): string {
     const { year, month, slug } = post;
     return `/blog/post/${year}/${month}/${slug}`;
+  }
+
+  static getUrlForCategoryPage(category: string): string {
+    return `/blog/categories/${kebabCase(category)}`;
+  }
+
+  static getUrlForTagPage(tag: string): string {
+    return `/blog/tags/${kebabCase(tag)}`;
   }
 
   static getDateOfPost(post: Post): Date {


### PR DESCRIPTION
We weren't including any of the meta pages about the site. This commit does that while extracting some url generation that would soon be shared into the presenter.

I also updated the `build_sitemap` to generate something that looked nicer and had a closing `xml` tag.

This also changes the sitemap generation to include all pages and not remove delisted posts.