### PR TITLE
Fix sitemap by removing xml tag

### DIFF
--- a/scripts/build_sitemap.ts
+++ b/scripts/build_sitemap.ts
@@ -36,7 +36,6 @@ function generateSiteMap(pages: Array<SiteMapPageInfo>) {
     .map((pageInfo) => renderUrl(pageInfo))
     .join("")}
   </urlset>
-</xml>
 `;
 }
 


### PR DESCRIPTION
Turns out that I misread the first line of the generated xml file and thought that that was a opening xml tag.