### PR TITLE
Change dependency updates to be monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "10:00"
     open-pull-requests-limit: 10
     commit-message:


### PR DESCRIPTION
Keeping things up to date on a weekly basis is mostly wasteful. The nature of the publishing of the project makes me less concerned about security issues that could arise from old dependencies.