### PR TITLE
Add a canonical link to the header

### DIFF
--- a/components/seo.tsx
+++ b/components/seo.tsx
@@ -1,5 +1,8 @@
 import React from "react";
+import { useRouter } from "next/router";
 import Head from "next/head";
+
+import { getBaseUrl } from "../services/url";
 
 type MetaItem =
   | { name: string; content: any }
@@ -14,6 +17,8 @@ interface SEOProps {
 const SEO = ({ description, title }: SEOProps): JSX.Element => {
   const metaDescription =
     description || "The personal website of Douglas Anderson";
+  const router = useRouter();
+  const canonicalUrl = `${getBaseUrl()}${router.asPath}`.replace(/\/$/, "");
 
   return (
     <Head>
@@ -28,6 +33,8 @@ const SEO = ({ description, title }: SEOProps): JSX.Element => {
       />
       <meta name={`twitter:title`} content={title} />
       <meta name={`twitter:description`} content={metaDescription} />
+      <link rel="canonical" href={canonicalUrl} key="canonical" />
+
       <title>{title}</title>
     </Head>
   );

--- a/scripts/build_sitemap.ts
+++ b/scripts/build_sitemap.ts
@@ -8,6 +8,7 @@ import {
 import { getAllProjects } from "../services/projects";
 import { BlogPresentor } from "../services/presentors/blog";
 import { ProjectPresentor } from "../services/presentors/project";
+import { getBaseUrl } from "../services/url";
 
 interface SiteMapPageInfo {
   loc: string;
@@ -39,7 +40,7 @@ function generateSiteMap(pages: Array<SiteMapPageInfo>) {
 `;
 }
 
-const BASE = "https://hockeybuggy.com";
+const BASE = getBaseUrl();
 
 async function generate() {
   console.log("Generating Sitemap...");

--- a/services/url.ts
+++ b/services/url.ts
@@ -1,0 +1,5 @@
+const BASE_URL = process.env.URL;
+
+export function getBaseUrl() {
+  return BASE_URL || "https://hockeybuggy.com";
+}


### PR DESCRIPTION
I am seeing some warnings in Google related to not having a user selected canonical on a page.

This commit adds this by introducing a utility to get the full url of the page. We then use this in both the site map and the seo component used in the layout of the page.