### PR TITLE
Trim trailing `index.html` from canonical urls

### DIFF
--- a/components/seo.tsx
+++ b/components/seo.tsx
@@ -18,7 +18,9 @@ const SEO = ({ description, title }: SEOProps): JSX.Element => {
   const metaDescription =
     description || "The personal website of Douglas Anderson";
   const router = useRouter();
-  const canonicalUrl = `${getBaseUrl()}${router.asPath}`.replace(/\/$/, "");
+  const canonicalUrl = `${getBaseUrl()}${router.asPath}`
+    .replace(/index.html$/, "")
+    .replace(/\/$/, "");
 
   return (
     <Head>


### PR DESCRIPTION
Google is complaining about a page which is
`https://hockeybuggy.com/index.html`. After
https://github.com/hockeybuggy/hockeybuggy.com/pull/2011 I thought that would resolve it, but it didn't (which makes sense in retrospect since it's included as the `asPath`).