### PR TITLE
Fix the hamburger menu

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -82,7 +82,7 @@ const Navigation = (props: { pathname?: string }): JSX.Element => {
           aria-controls="menu-inner"
           ref={navigationToggleRef}
         >
-          <Icon name={Icon.Names.Bars} label="" width="24" />
+          <Icon name={Icon.Names.Bars} label="" width="24px" />
         </button>
 
         <ul


### PR DESCRIPTION
We were rendering the hamburger at 0 width because the setting of the size was changed in the switch to inline svgs:
https://github.com/hockeybuggy/hockeybuggy.com/pull/2000/files#diff-87965675eb054932993012ea135fb551085d338e8ddcf7f480faf1ad2481286cR85

This commit switches back to specify pixels which restores the menu.