### PR TITLE
Update GitHub actions versions.

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache next build cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/.next/cache
@@ -16,7 +16,7 @@ runs:
 
     - name: Cache next build
       id: cache-next-build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/public

--- a/.github/actions/shared-setup/action.yml
+++ b/.github/actions/shared-setup/action.yml
@@ -5,9 +5,9 @@ description: "Used to share steps between jobs that install node dependancies fo
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 20.16.0
         cache: 'yarn'

--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -6,7 +6,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/shared-setup
 
 
@@ -14,7 +14,7 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/shared-setup
     - name: Check Types
       run: |
@@ -31,7 +31,7 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/shared-setup
     - uses: ./.github/actions/build-site
 
@@ -40,7 +40,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/shared-setup
     - uses: ./.github/actions/build-site
     - name: Run Tests
@@ -54,7 +54,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/shared-setup
     - uses: ./.github/actions/build-site
     - name: Run Tests
@@ -62,7 +62,7 @@ jobs:
         CI: true
       run: |
         yarn run test:e2e --verbose
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: e2e_test_screenshots
         path: e2e_tests/screenshots


### PR DESCRIPTION
This picks up a newer version of Node and quiets some warnings for us.