### PR TITLE
Update the copyright year

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -6,7 +6,6 @@ import Icon from "../components/icon";
 interface Props {
   showRSSLink?: boolean;
 }
-
 const Footer = (props: Props): React.ReactElement => {
   return (
     <footer className="footer">
@@ -29,7 +28,7 @@ const Footer = (props: Props): React.ReactElement => {
               <Icon name={Icon.Names.RSS} label="RSS feed icon" />
             </Link>
           )}
-          <span>©2023</span>
+          <span>©2024</span>
         </div>
       </section>
     </footer>

--- a/styles/_footer.scss
+++ b/styles/_footer.scss
@@ -22,6 +22,7 @@
     span,
     a {
       display: flex;
+      align-items: center;
       padding: 0 0.5rem;
       min-width: 28px;
       min-height: 22px;


### PR DESCRIPTION
This commit also fixes the alignment of the icon.

Closes: #2159

## Before
<img width="246" alt="Screenshot 2024-10-17 at 16 25 36" src="https://github.com/user-attachments/assets/49f484c6-f5a7-40be-88b0-72e0a1b5728d">



## After
<img width="264" alt="Screenshot 2024-10-21 at 15 01 55" src="https://github.com/user-attachments/assets/130f9170-aa25-46d7-9172-c8f1bc81932b">

