### PR TITLE
Add more extensive screenshots

### DIFF
--- a/e2e_tests/blog.test.ts
+++ b/e2e_tests/blog.test.ts
@@ -117,11 +117,6 @@ describe("/blog (Blog index Page)", () => {
     await loadPage(page, BLOG_PAGE.url);
 
     expect(errors).toEqual([]);
-
-    // Not related to this specific assertion but while we're here:
-    await page.screenshot({
-      path: `e2e_tests/screenshots/blog_index_page.png`,
-    });
   });
 
   it("should have links to many blog posts", async () => {
@@ -143,6 +138,48 @@ describe("/blog (Blog index Page)", () => {
     );
 
     expect(blogPosts).toEqual(indexListedBlogPosts);
+  });
+
+  describe("screenshots", () => {
+    test("iPhone light", async () => {
+      await loadPage(page, BLOG_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_index_page__iPhone_light.png`,
+      });
+    });
+
+    test("iPhone dark", async () => {
+      await loadPage(page, BLOG_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_index_page__iPhone_dark.png`,
+      });
+    });
+
+    test("iPad light", async () => {
+      await loadPage(page, BLOG_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_index_page__iPad_light.png`,
+      });
+    });
+
+    test("iPad dark", async () => {
+      await loadPage(page, BLOG_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_index_page__iPad_dark.png`,
+      });
+    });
   });
 });
 
@@ -172,11 +209,6 @@ describe("/blog/tags (Blog tags index Page)", () => {
     await loadPage(page, TAGS_PAGE.url);
 
     expect(errors).toEqual([]);
-
-    // Not related to this specific assertion but while we're here:
-    await page.screenshot({
-      path: `e2e_tests/screenshots/tags_index_page.png`,
-    });
   });
 
   it("should have a title", async () => {
@@ -194,6 +226,48 @@ describe("/blog/tags (Blog tags index Page)", () => {
       });
     });
     expect(tagLinks).toEqual(expectedTagLinks);
+  });
+
+  describe("screenshots", () => {
+    test("iPhone light", async () => {
+      await loadPage(page, TAGS_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_tags_index_page__iPhone_light.png`,
+      });
+    });
+
+    test("iPhone dark", async () => {
+      await loadPage(page, TAGS_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_tags_index_page__iPhone_dark.png`,
+      });
+    });
+
+    test("iPad light", async () => {
+      await loadPage(page, TAGS_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_tags_index_page__iPad_light.png`,
+      });
+    });
+
+    test("iPad dark", async () => {
+      await loadPage(page, TAGS_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_tags_index_page__iPad_dark.png`,
+      });
+    });
   });
 });
 
@@ -235,11 +309,6 @@ describe("/blog/categories (Blog categories index Page)", () => {
     await loadPage(page, CATEGORIES_PAGE.url);
 
     expect(errors).toEqual([]);
-
-    // Not related to this specific assertion but while we're here:
-    await page.screenshot({
-      path: `e2e_tests/screenshots/categories_index_page.png`,
-    });
   });
 
   it("should have a title", async () => {
@@ -257,6 +326,48 @@ describe("/blog/categories (Blog categories index Page)", () => {
       });
     });
     expect(categoryLinks).toEqual(expectedCategoryLinks);
+  });
+
+  describe("screenshots", () => {
+    test("iPhone light", async () => {
+      await loadPage(page, CATEGORIES_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_categories_index_page__iPhone_light.png`,
+      });
+    });
+
+    test("iPhone dark", async () => {
+      await loadPage(page, CATEGORIES_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_categories_index_page__iPhone_dark.png`,
+      });
+    });
+
+    test("iPad light", async () => {
+      await loadPage(page, CATEGORIES_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_categories_index_page__iPad_light.png`,
+      });
+    });
+
+    test("iPad dark", async () => {
+      await loadPage(page, CATEGORIES_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/blog_categories_index_page__iPad_dark.png`,
+      });
+    });
   });
 });
 

--- a/e2e_tests/landingPage.test.ts
+++ b/e2e_tests/landingPage.test.ts
@@ -13,15 +13,52 @@ describe("/ (Landing Page)", () => {
     await loadPage(page, LANDING_PAGE.url);
 
     expect(errors).toEqual([]);
-
-    // Not related to this specific assertion but while we're here:
-    await page.screenshot({
-      path: `e2e_tests/screenshots/landing_page.png`,
-    });
   });
 
   it("should have a title", async () => {
     await loadPage(page, LANDING_PAGE.url);
     expect(await page.title()).toEqual(LANDING_PAGE.expected.title);
+  });
+
+  describe("screenshots", () => {
+    test("iPhone light", async () => {
+      await loadPage(page, LANDING_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/landing_page__iPhone_light.png`,
+      });
+    });
+
+    test("iPhone dark", async () => {
+      await loadPage(page, LANDING_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/landing_page__iPhone_dark.png`,
+      });
+    });
+
+    test("iPad light", async () => {
+      await loadPage(page, LANDING_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/landing_page__iPad_light.png`,
+      });
+    });
+
+    test("iPad dark", async () => {
+      await loadPage(page, LANDING_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/landing_page__iPad_dark.png`,
+      });
+    });
   });
 });

--- a/e2e_tests/projects.test.ts
+++ b/e2e_tests/projects.test.ts
@@ -34,6 +34,48 @@ const expectedProjects = [
 ];
 
 describe("/projects (Projects index Page)", () => {
+  describe("screenshots", () => {
+    test("iPhone light", async () => {
+      await loadPage(page, PROJECTS_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/projects_index_page__iPhone_light.png`,
+      });
+    });
+
+    test("iPhone dark", async () => {
+      await loadPage(page, PROJECTS_PAGE.url, "iPhone 6");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/projects_index_page__iPhone_dark.png`,
+      });
+    });
+
+    test("iPad light", async () => {
+      await loadPage(page, PROJECTS_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "light" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/projects_index_page__iPad_light.png`,
+      });
+    });
+
+    test("iPad dark", async () => {
+      await loadPage(page, PROJECTS_PAGE.url, "iPad Pro");
+      await page.emulateMediaFeatures([
+        { name: "prefers-color-scheme", value: "dark" },
+      ]);
+      await page.screenshot({
+        path: `e2e_tests/screenshots/projects_index_page__iPad_dark.png`,
+      });
+    });
+  });
+
   it("should load without error", async () => {
     const errors: Array<{ errorMessage: string }> = [];
     page.on("console", (msg) => {
@@ -45,11 +87,6 @@ describe("/projects (Projects index Page)", () => {
     await loadPage(page, PROJECTS_PAGE.url);
 
     expect(errors).toEqual([]);
-
-    // Not related to this specific assertion but while we're here:
-    await page.screenshot({
-      path: `e2e_tests/screenshots/projects_index_page.png`,
-    });
   });
 
   it("should have links to many projects", async () => {

--- a/e2e_tests/utils.ts
+++ b/e2e_tests/utils.ts
@@ -1,12 +1,14 @@
 import { KnownDevices } from "puppeteer";
 
-const iPhone = KnownDevices["iPhone 6"];
-
 /* This helper function takes a Puppetter `page` and a `url` and loads the
  * page, responding when all requests have completed.
  */
-const loadPage = async (page: any, url: string) => {
-  await page.emulate(iPhone);
+const loadPage = async (
+  page: any,
+  url: string,
+  device?: "iPhone 6" | "iPad Pro",
+) => {
+  await page.emulate(KnownDevices[device || "iPhone 6"]);
   const response = await page.goto(url, {
     waitUntil: "networkidle2",
   });


### PR DESCRIPTION
We we only capturing screenshots of an iPhone 6 with light mode. This commit updates the screenshotting to capture different sizes of devices (uses a "pretty big iPad" as a proxy for all larger devices). This commit also captures screenshots of dark mode.

Closes: #2169 #2168 