### PR TITLE
The linting warnings about tests with no assertions.

### DIFF
--- a/e2e_tests/blog.test.ts
+++ b/e2e_tests/blog.test.ts
@@ -151,9 +151,10 @@ describe("/blog (Blog index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_index_page__iPhone_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPhone dark", async () => {
@@ -161,9 +162,10 @@ describe("/blog (Blog index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_index_page__iPhone_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad light", async () => {
@@ -171,9 +173,10 @@ describe("/blog (Blog index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_index_page__iPad_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad dark", async () => {
@@ -181,9 +184,10 @@ describe("/blog (Blog index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_index_page__iPad_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
   });
 });
@@ -239,9 +243,10 @@ describe("/blog/tags (Blog tags index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_tags_index_page__iPhone_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPhone dark", async () => {
@@ -249,9 +254,10 @@ describe("/blog/tags (Blog tags index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_tags_index_page__iPhone_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad light", async () => {
@@ -259,9 +265,10 @@ describe("/blog/tags (Blog tags index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_tags_index_page__iPad_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad dark", async () => {
@@ -269,9 +276,10 @@ describe("/blog/tags (Blog tags index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_tags_index_page__iPad_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
   });
 });
@@ -339,9 +347,10 @@ describe("/blog/categories (Blog categories index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_categories_index_page__iPhone_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPhone dark", async () => {
@@ -349,9 +358,10 @@ describe("/blog/categories (Blog categories index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_categories_index_page__iPhone_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad light", async () => {
@@ -359,9 +369,10 @@ describe("/blog/categories (Blog categories index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_categories_index_page__iPad_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad dark", async () => {
@@ -369,9 +380,10 @@ describe("/blog/categories (Blog categories index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/blog_categories_index_page__iPad_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
   });
 });

--- a/e2e_tests/landingPage.test.ts
+++ b/e2e_tests/landingPage.test.ts
@@ -26,9 +26,10 @@ describe("/ (Landing Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/landing_page__iPhone_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPhone dark", async () => {
@@ -36,9 +37,10 @@ describe("/ (Landing Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/landing_page__iPhone_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad light", async () => {
@@ -46,9 +48,10 @@ describe("/ (Landing Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/landing_page__iPad_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad dark", async () => {
@@ -56,9 +59,10 @@ describe("/ (Landing Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/landing_page__iPad_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
   });
 });

--- a/e2e_tests/projects.test.ts
+++ b/e2e_tests/projects.test.ts
@@ -40,9 +40,10 @@ describe("/projects (Projects index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/projects_index_page__iPhone_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPhone dark", async () => {
@@ -50,9 +51,10 @@ describe("/projects (Projects index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/projects_index_page__iPhone_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad light", async () => {
@@ -60,9 +62,10 @@ describe("/projects (Projects index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "light" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/projects_index_page__iPad_light.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
 
     test("iPad dark", async () => {
@@ -70,9 +73,10 @@ describe("/projects (Projects index Page)", () => {
       await page.emulateMediaFeatures([
         { name: "prefers-color-scheme", value: "dark" },
       ]);
-      await page.screenshot({
+      const screenshot = await page.screenshot({
         path: `e2e_tests/screenshots/projects_index_page__iPad_dark.png`,
       });
+      expect(screenshot).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
We were getting a number of "Test has no assertions" warnings. This commit resolves those by checking the return value from the `screenshot` call (which is a string of somekind; don't know what it's value is).

Closes: https://github.com/hockeybuggy/hockeybuggy.com/issues/2231