### PR TITLE
chore(deps): add jest-util as explicit devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^17.4.2",
     "jest": "^30.3.0",
     "jest-puppeteer": "^11.0.0",
+    "jest-util": "^30.0.0",
     "puppeteer": "^24.41.0",
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,6 +3001,7 @@ __metadata:
     dotenv: "npm:^17.4.2"
     jest: "npm:^30.3.0"
     jest-puppeteer: "npm:^11.0.0"
+    jest-util: "npm:^30.0.0"
     puppeteer: "npm:^24.41.0"
     ts-jest: "npm:^29.4.9"
     typescript: "npm:^6.0.3"
@@ -3758,7 +3759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:30.3.0":
+"jest-util@npm:30.3.0, jest-util@npm:^30.0.0":
   version: 30.3.0
   resolution: "jest-util@npm:30.3.0"
   dependencies:


### PR DESCRIPTION
jest-util was only being pulled in transitively through jest, so nothing in our own code could import it directly without relying on hoisting behavior that isn't guaranteed under Yarn PnP / strict resolution. This made test helpers that need jest-util fragile.

This commit promotes jest-util to a direct devDependency pinned to ^30.0.0 so it resolves deterministically alongside the existing jest@^30.3.0. The yarn.lock update merges the new range into the existing 30.3.0 resolution, so no package versions actually change.