### PR TITLE
Update Rust edition to 2024 and bump deps

### DIFF
--- a/ssg/Cargo.lock
+++ b/ssg/Cargo.lock
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.3"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "getopts",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]

--- a/ssg/Cargo.toml
+++ b/ssg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ssg"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "ssg"
@@ -12,6 +12,6 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 grass = { version = "0.13", default-features = false }
 minijinja = { version = "2", features = ["loader"] }
-pulldown-cmark = "0.11"
+pulldown-cmark = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/ssg/src/content/markdown.rs
+++ b/ssg/src/content/markdown.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{html, Options, Parser};
+use pulldown_cmark::{Options, Parser, html};
 
 /// Render full markdown to HTML, removing the excerpt marker.
 pub fn markdown_to_html(markdown: &str) -> String {


### PR DESCRIPTION
The SSG crate was on the 2021 edition and had a couple of dependency updates available, including a major-version bump for `pulldown-cmark`.

This commit moves `ssg` to edition 2024, upgrades `pulldown-cmark` from 0.11 to 0.13, and picks up a patch bump of `rand` via `cargo update`. The 2024 edition's rustfmt reorders the `pulldown_cmark` import alphabetically in `markdown.rs`. Build, tests, clippy, and fmt all pass.

Closes: #2329