### PR TITLE
Add a dead-link checker using lychee

### DIFF
--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -1,0 +1,39 @@
+name: external link check
+
+on:
+  schedule:
+    # Weekly, Monday 12:00 UTC. External link rot happens on calendar time,
+    # not on push cadence, so this doesn't need to run more often than that.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+jobs:
+  link-check-external:
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+    steps:
+    - uses: actions/checkout@v5
+    - uses: ./.github/actions/build-site
+    - name: Check internal and external links
+      id: lychee
+      uses: lycheeverse/lychee-action@v2
+      with:
+        lycheeVersion: v0.24.2
+        args: >-
+          --no-progress
+          --root-dir ${{ github.workspace }}/dist
+          --config lychee.toml
+          './dist/**/*.html'
+        fail: false
+        # Networked checks are flaky (rate limits, transient downtime), so
+        # this job never fails the build. Broken links are reported via a
+        # GitHub issue instead.
+
+    - name: Report broken links
+      if: steps.lychee.outputs.exit_code != 0
+      uses: peter-evans/create-issue-from-file@v5
+      with:
+        title: Link Checker Report
+        content-filepath: ./lychee/out.md
+        labels: link-check

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -19,7 +19,6 @@ jobs:
       id: lychee
       uses: lycheeverse/lychee-action@v2
       with:
-        lycheeVersion: v0.24.2
         args: >-
           --no-progress
           --root-dir ${{ github.workspace }}/dist

--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -46,3 +46,21 @@ jobs:
         path: |
           playwright-report/
           e2e_tests/screenshots/
+
+
+  link-check:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v5
+    - uses: ./.github/actions/build-site
+    - name: Check internal links
+      uses: lycheeverse/lychee-action@v2
+      with:
+        lycheeVersion: v0.24.2
+        args: >-
+          --offline --no-progress
+          --root-dir ${{ github.workspace }}/dist
+          --config lychee.toml
+          './dist/**/*.html'
+        fail: true

--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -57,7 +57,6 @@ jobs:
     - name: Check internal links
       uses: lycheeverse/lychee-action@v2
       with:
-        lycheeVersion: v0.24.2
         args: >-
           --offline --no-progress
           --root-dir ${{ github.workspace }}/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,14 @@ fully static site built by a small custom Rust static site generator in
 - `e2e_tests/` — Puppeteer-driven Jest tests that hit the built site served by
   `serve_static.js`, including validation of generated artifacts like the
   sitemap. Run with `yarn test:e2e` (or `./scripts/test`).
+- **Link checking:** [`lychee`](https://lychee.cli.rs) checks the built site
+  (`dist/`) for dead links, configured via `lychee.toml`. Run locally with
+  `./scripts/check-links` (internal links only, offline) or
+  `./scripts/check-links --external` (also checks external URLs over the
+  network). Internal links are checked on every push (`link-check` job);
+  external links are checked weekly (`.github/workflows/link-check-external.yml`)
+  and reported via a GitHub issue rather than failing the build, since
+  networked checks are flaky.
 
 ## Development Workflow
 
@@ -49,6 +57,7 @@ fully static site built by a small custom Rust static site generator in
 | Rust tests | `cargo test --manifest-path ssg/Cargo.toml` |
 | Rust format check | `cargo fmt --manifest-path ssg/Cargo.toml --check` |
 | Rust lints | `cargo clippy --manifest-path ssg/Cargo.toml -- -D warnings` |
+| Check for dead links | `./scripts/check-links` (add `--external` for network checks) |
 
 ### Adding a New Blog Post
 
@@ -85,4 +94,4 @@ fully static site built by a small custom Rust static site generator in
 - `dist/` — Build output (gitignored, produced by `yarn build`).
 - `e2e_tests/` — Puppeteer end-to-end tests, including artifact validation
   (sitemap, etc.).
-- `scripts/` — Helper scripts (new post, dev server, test runner).
+- `scripts/` — Helper scripts (new post, dev server, test runner, link checker).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ See `AGENTS.md` for a full architecture overview.
 - Run single E2E test: `JEST_PUPPETEER_CONFIG=e2e_tests/jest-puppeteer.config.js jest --runInBand -c 'e2e_tests/jest.config.js' -t 'test name'`
 - Rust tests: `cargo test --manifest-path ssg/Cargo.toml`
 - Rust format / lint: `cargo fmt --manifest-path ssg/Cargo.toml --check` and `cargo clippy --manifest-path ssg/Cargo.toml -- -D warnings`
+- Check for dead links: `./scripts/check-links` (internal only, offline) or `./scripts/check-links --external` (also checks external URLs); requires `lychee` (`brew install lychee`)
 
 ## Code Style Guidelines
 - Rust SSG lives under `ssg/`. Run `cargo fmt` and `cargo clippy` before committing Rust changes.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ rendered through [MiniJinja](https://docs.rs/minijinja) templates in
 - Node and [`yarn`](https://yarnpkg.com/) to run the Jest-based end-to-end
   tests. This README assumes [`fnm`](https://github.com/Schniz/fnm) is used but
   any node installer works.
+- [`lychee`](https://lychee.cli.rs) to check for dead links (`brew install
+  lychee` or `cargo install lychee`).
 
 
 ## Making Changes
@@ -96,6 +98,21 @@ Rust-side unit tests and lints:
     cargo test
     cargo fmt --check
     cargo clippy -- -D warnings
+
+
+### Checking links
+
+Check the built site for dead links (internal links only, no network access):
+
+    ./scripts/check-links
+
+To also check external URLs over the network:
+
+    ./scripts/check-links --external
+
+Internal links are checked on every push and block CI. External links are
+checked weekly and reported as a GitHub issue instead of failing the build,
+since networked checks are inherently flaky.
 
 
 ### Deployment

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,25 @@
+# Config for the dead-link checker (scripts/check-links, CI link-check jobs).
+# See: https://lychee.cli.rs/formats/#config-file
+
+# Resolve directory links (e.g. `/blog/`) against index.html when checking
+# the built site locally.
+index_files = ["index.html"]
+
+# Don't flag loopback/localhost addresses (e.g. the http://localhost:8080
+# example used in a blog post about local development).
+exclude_loopback = true
+
+# Known false positives and out-of-scope URLs:
+exclude = [
+    # XML/SVG namespace URIs, not real links.
+    '^https?://www\.w3\.org/',
+    '^https?://www\.sitemaps\.org/',
+]
+
+# Many sites block the default lychee/reqwest user agent.
+user_agent = "Mozilla/5.0 (compatible; hockeybuggy.com link-check)"
+
+# Be a little more tolerant of slow/rate-limited hosts.
+timeout = 20
+retry_wait_time = 5
+max_retries = 3

--- a/scripts/check-links
+++ b/scripts/check-links
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks the built site for dead links using lychee (https://lychee.cli.rs).
+#
+# By default only internal links are checked, offline against the built
+# `dist/` directory (fast, deterministic, safe to run on every push).
+# Pass --external to also check external URLs over the network.
+
+if ! command -v lychee >/dev/null 2>&1; then
+    echo "==> lychee is not installed." >&2
+    echo "    Install it with: brew install lychee" >&2
+    echo "    or:              cargo install lychee" >&2
+    exit 1
+fi
+
+MODE="internal"
+if [[ "${1:-}" == "--external" ]]; then
+    MODE="external"
+fi
+
+echo "==> Building site"
+yarn run build
+
+LYCHEE_ARGS=(--root-dir "$PWD/dist" --config lychee.toml 'dist/**/*.html')
+if [[ "$MODE" == "internal" ]]; then
+    echo "==> Checking internal links (offline)"
+    lychee --offline "${LYCHEE_ARGS[@]}"
+else
+    echo "==> Checking internal and external links"
+    lychee "${LYCHEE_ARGS[@]}"
+fi


### PR DESCRIPTION
## Summary

Nothing verified that links on the site still resolved, so link rot could accumulate silently. This adds `lychee` as the link-checking engine, with `lychee.toml` as shared config for local and CI runs.

Internal links (root-relative paths against the built `dist/`) are checked offline and block every push via a new `link-check` job in `tests_and_linting.yml`, since that check is fully deterministic. External links are checked over the network on a weekly schedule (`link-check-external.yml`) and reported via a GitHub issue instead of failing the build, since networked checks are flaky and shouldn't red-build unrelated pushes.

`scripts/check-links` wraps `lychee` for local use, checking it's installed and building the site first. Docs in README/AGENTS/CLAUDE are updated to reference the new command and jobs.

(A follow-up commit drops an explicit `lycheeVersion` pin — the pinned release's tarball layout broke `lychee-action`'s install step, confirmed by watching the job fail in CI; the action's own default version works correctly.)

## Test plan
- [x] `./scripts/check-links` passes locally against a clean build (0 errors)
- [x] Verified failure path: deliberately broke an internal link, confirmed the script fails and names it, reverted
- [x] Verified missing-lychee-binary hint prints and exits non-zero
- [x] `./scripts/check-links --external` run locally surfaced real dead links (pre-existing, out of scope for this PR — see note below)
- [x] Pushed the branch and confirmed the `link-check` CI job passes for real (643 links checked, 0 errors)
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass
- [ ] `link-check-external.yml` (schedule/workflow_dispatch) can only be verified once merged to `main`

## Note
The external check found real dead links already on the site (a `bit.ly` shortener, three renamed paths in the `dotfiles` project's GitHub links, a dead `makeblock.com` URL). Fixing those is left for a follow-up, out of scope here.