### PR TITLE
Fix dead links on the project pages

### DIFF
--- a/content/blog/2013-09-10-misc_kbnlnguhi.md
+++ b/content/blog/2013-09-10-misc_kbnlnguhi.md
@@ -39,10 +39,8 @@ of the files in the root of the project.
 ## New Face
 
 So now that I have to redo all of my markup I figured it was time for a new
-face for the site. I keep the same colour scheme(borrowed from:[here][COLOUR])
-and added some icons in the footer.
+face for the site.
 
 [PELICAN]: https://docs.getpelican.com
 [JEKYLL]: https://jekyllrb.com
 [GITHUB]: https://pages.github.com
-[COLOUR]: https://bit.ly/9oo0N3

--- a/content/projects/dotfiles.md
+++ b/content/projects/dotfiles.md
@@ -18,12 +18,12 @@ repository has history going back to early 2012.
 My primary editor is Vim. I use Neovim as the distribution, and use
 [coc.nvim](https://github.com/neoclide/coc.nvim) for completions and language
 server integrations. My Vim configuration [can be found
-here](https://github.com/hockeybuggy/dotfiles/blob/main/vimrc)
+here](https://github.com/hockeybuggy/dotfiles/blob/main/.config/nvim/init.lua)
 
 ## Git
 
 My [git
-configuration](https://github.com/hockeybuggy/dotfiles/blob/main/gitconfig) has
+configuration](https://github.com/hockeybuggy/dotfiles/blob/main/.gitconfig) has
 quite a few aliases. I also use
 [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy) to get some nicer
 looking diffs. I tend to sign all of my commits with GPG.
@@ -35,6 +35,6 @@ I use zsh (I am Canadian so it's "zed shell") as my shell and I used
 rust that is very fast, configurable and fully featured).
 
 All of the aliases I use are [split into a
-file](https://github.com/hockeybuggy/dotfiles/blob/main/aliases) that is
+file](https://github.com/hockeybuggy/dotfiles/blob/main/.aliases) that is
 separate from zsh config so that I can also make them available if I wanted to
 use bash

--- a/content/projects/rbg-tsp-art.md
+++ b/content/projects/rbg-tsp-art.md
@@ -40,7 +40,8 @@ or the route between stipples.
 ## Plotter
 
 The plotter that I am using is a [MakeBlock XY Plotter Robot
-Kit](https://www.makeblock.com/project/xy-plotter-robot-kit). This plotter
+Kit](https://web.archive.org/web/20230306200404/https://www.makeblock.com/project/xy-plotter-robot-kit).
+This plotter
 comes with some software called `mDraw` which I used to control the plotter
 from a computer.
 


### PR DESCRIPTION
The link checker flagged four dead external links. The dotfiles repo renamed its config files to use leading dots (and moved the Vim config to Neovim's Lua init), and MakeBlock removed the XY plotter product page entirely.

Point the dotfiles links at their current paths (`.config/nvim/init.lua`, `.gitconfig`, `.aliases`) and replace the MakeBlock link with a Wayback Machine snapshot of the original page.

Fixes: #2365 