### PR TITLE
Refresh the dotfiles project page

### DIFF
--- a/content/projects/dotfiles.md
+++ b/content/projects/dotfiles.md
@@ -8,16 +8,22 @@ bannerAltText: "A screenshot of my configuration files or dotfiles. The image de
 ---
 
 This "project" is my configuration files for setting up a computer. It contains
-aliases and options for setting up the software I use day to day. This
-repository has history going back to early 2012.
+aliases and options for setting up the software I use day to day. A
+`bootstrap.sh` script symlinks everything into place. This repository has
+history going back to early 2012.
 
 <!-- excerpt -->
 
-## Vim
+## Neovim
 
-My primary editor is Vim. I use Neovim as the distribution, and use
-[coc.nvim](https://github.com/neoclide/coc.nvim) for completions and language
-server integrations. My Vim configuration [can be found
+My primary editor is Neovim. My configuration is a Lua config based on
+[kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim) and managed with
+[lazy.nvim](https://github.com/folke/lazy.nvim). I use Neovim's built-in LSP
+for completions and language server integrations, along with
+[Treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for syntax,
+[Telescope](https://github.com/nvim-telescope/telescope.nvim) for fuzzy
+finding, and [conform.nvim](https://github.com/stevearc/conform.nvim) for
+formatting. My configuration [can be found
 here](https://github.com/hockeybuggy/dotfiles/blob/main/.config/nvim/init.lua)
 
 ## Git
@@ -38,3 +44,19 @@ All of the aliases I use are [split into a
 file](https://github.com/hockeybuggy/dotfiles/blob/main/.aliases) that is
 separate from zsh config so that I can also make them available if I wanted to
 use bash
+
+## Command line tools
+
+Over the years I have replaced a lot of the standard Unix tools with faster,
+friendlier alternatives (many of them written in Rust):
+
+- [`eza`](https://eza.rocks/) in place of `ls`
+- [`bat`](https://github.com/sharkdp/bat) in place of `cat`
+- [`ripgrep`](https://github.com/BurntSushi/ripgrep) in place of `grep`
+- [`fd`](https://github.com/sharkdp/fd) in place of `find`
+- [`fzf`](https://github.com/junegunn/fzf) for fuzzy finding
+- [`zoxide`](https://github.com/ajeetdsouza/zoxide) for jumping between
+  directories
+
+A lot of my aliases wire these tools together, and I lean on `fzf` in both the
+shell and inside Neovim.


### PR DESCRIPTION
The dotfiles project page described an editor setup that no longer matches the repository. It claimed Neovim was configured with coc.nvim for completions and language servers, but the config has since been rewritten as a Lua config based on kickstart.nvim and lazy.nvim using Neovim's built-in LSP.

Rewrite the editor section to describe the current Neovim setup (kickstart.nvim, lazy.nvim, built-in LSP, Treesitter, Telescope, and conform.nvim) and add a section covering the modern command line tools now in the repo (`eza`, `bat`, `ripgrep`, `fd`, `fzf`, and `zoxide`). Also mention the `bootstrap.sh` symlink script in the intro.