### PR TITLE
Refresh the this-site and ray-tracer project pages

### DIFF
--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   link-check-external:
-    runs-on: ubuntu-22.04
+    # ubuntu-24.04 (glibc 2.39): the unpinned lychee release now requires a
+    # newer glibc than ubuntu-22.04 (glibc 2.35) provides.
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -50,7 +50,9 @@ jobs:
 
   link-check:
     needs: build
-    runs-on: ubuntu-22.04
+    # ubuntu-24.04 (glibc 2.39): the unpinned lychee release now requires a
+    # newer glibc than ubuntu-22.04 (glibc 2.35) provides.
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
     - uses: ./.github/actions/build-site

--- a/content/projects/ray-tracer.md
+++ b/content/projects/ray-tracer.md
@@ -27,6 +27,7 @@ there was no library code. Now the only libraries I use in this project are:
 - [`image`](https://crates.io/crates/image): Used to render jpegs of the rendered canvases
 - [`criterion`](https://crates.io/crates/criterion): Used to benchmark the performance of the rendering (because it can be quite slow when there are a lot of pixels in an image)
 - [`assert_approx_eq`](https://crates.io/crates/assert_approx_eq): Used to make fuzzy assertions on floating point numbers
+- [`serde`](https://crates.io/crates/serde) and [`toml`](https://crates.io/crates/toml): Used to read scenes and animations described in TOML files
 
 ---
 
@@ -94,9 +95,26 @@ project's readme](https://github.com/hockeybuggy/ray_tracer#worlds)
 
 ---
 
-I haven't quite finished the book yet at this point (2023-02-18). There are a
-few more chapters that I haven't gotten to yet, but I am quite content with
-where the project is now and may never choose to "finish".
+The project has come a long way since those first spheres. Beyond planes and
+spheres it can now render cubes, cylinders and cones, groups of shapes, triangle
+meshes imported from OBJ models, and objects combined with constructive solid
+geometry (CSG). It also gained texture mapping (including a skybox), area lights
+that cast soft shadows, and bounding volume hierarchies to keep all of that fast
+enough to render. Scenes no longer have to be described in Rust either: a
+`render` binary reads a scene from a TOML file and writes a PNG, and an
+`animate` binary turns a TOML animation into a sequence of frames. The
+[project's readme has a
+gallery](https://github.com/hockeybuggy/ray_tracer#gallery) of what it can
+render.
+
+---
+
+This started as a follow-along of the book, and I've since worked through the
+later chapters — cubes, cylinders and cones, groups, triangles and OBJ models,
+and on through constructive solid geometry (chapter 16). Even so, it remains an
+ongoing hobby project that may never be formally "done": there are always more
+bonus chapters to try, more scenes to render, and more Rust to learn along the
+way.
 
 
 [FIRST_SPHERE]: /static/img/projects/ray-tracer/first_sphere.jpg

--- a/content/projects/this-site.md
+++ b/content/projects/this-site.md
@@ -76,12 +76,35 @@ For every commit it uses [Puppeteer](https://github.com/puppeteer/puppeteer) to
 check that pages render, don't log any errors to the console, and take screen
 shots.
 
+After Gatsby I ported the site to `Next.js`: [I wrote about
+it](/blog/post/2021/12/switching-to-next-js). I did this because I got a chance
+to use it at work and enjoyed it. Since this was already a React based site
+converting it from the Gatsby implementation was possible.
+
+Most recently I replaced Next.js with a small custom static site generator that
+I wrote myself: [I wrote about
+it](/blog/post/2026/04/custom-static-site-generator). I did this because the
+site is a low-stakes place to try things and I wanted to see what building my
+own generator would be like rather than reaching for another off-the-shelf
+framework.
+
 
 ### Today
 
-Today this uses `Next.js`. I got a chance to use it at work and enjoyed it.
-Since this was already a React based site converting it from the Gatsby
-implementation was possible.
+Today the site is built by a small custom static site generator written in Rust
+that lives in the `ssg/` directory of the repository. The content, both blog
+posts and these project pages, is authored as Markdown files with YAML
+frontmatter under `content/`. The generator parses that Markdown with
+`pulldown-cmark` and renders the pages using MiniJinja templates. The styles are
+written in Sass and compiled with `grass` as part of the build. The finished
+site is written to `dist/`, which is what Netlify publishes.
+
+I kept the parts of the previous incarnations that I liked. The end to end tests
+still use Puppeteer and Jest to check that the built pages render without logging
+errors to the console. I also added a step that uses
+[`lychee`](https://lychee.cli.rs) to check the site for dead links. None of this
+is fancy, but that suits the site: it is a low-stakes place for me to try things,
+and writing my own generator was one of those things.
 
 
 ## Plans for the future


### PR DESCRIPTION
Both project pages had drifted out of date with the projects they describe. The `this-site` page still claimed the site ran on Next.js, but it has since been rewritten as a small custom static site generator in Rust. The `ray-tracer` page was frozen at a 2023 note saying the book was unfinished, well before the project grew cubes, groups, OBJ meshes, CSG, texture mapping, area lights, and TOML-driven rendering.

Rewrite the `this-site` "Today" section to describe the Rust generator (`pulldown-cmark`, MiniJinja, `grass`, Netlify, `lychee`) and fold the Next.js era into the migration history, each linked to its blog post.

Refresh the `ray-tracer` page to reflect how far the project has come while keeping its honest "ongoing hobby project" framing, and add the `serde`/`toml` dependencies it now uses to read scene files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)